### PR TITLE
Apply recent changes in Docker

### DIFF
--- a/guide.sh
+++ b/guide.sh
@@ -138,8 +138,8 @@ find_files() {
     echo "$files" || echo "No $name files found."
 }
 
-find_files "$HOST_DATA_PATH" "catchment" "$UGreen"
-find_files "$HOST_DATA_PATH" "nexus" "$UGreen"
+find_files "$HOST_DATA_PATH" "datastream" "$UGreen"
+find_files "$HOST_DATA_PATH" "datastream" "$UGreen"
 find_files "$HOST_DATA_PATH" "realization" "$UGreen"
 
 # Detect Arch and Singularity

--- a/singularity/singularity_ngen.def
+++ b/singularity/singularity_ngen.def
@@ -24,7 +24,9 @@ From: rockylinux:9.2
      dnf --enablerepo=devel install texinfo -y
      dnf install netcdf netcdf-devel netcdf-fortran netcdf-fortran-devel netcdf-openmpi netcdf-openmpi-devel netcdf-fortran-openmpi netcdf-fortran-openmpi-devel -y 
      curl -L -o boost_1_79_0.tar.bz2 https://sourceforge.net/projects/boost/files/boost/1.79.0/boost_1_79_0.tar.bz2/download
-     tar -xjf boost_1_79_0.tar.bz2 /ngen/boost
+     tar -xjf boost_1_79_0.tar.bz2 -C /tmp/
+     cp -r /tmp/boost_1_79_0/boost /usr/include/
+     rm -rf /tmp/boost_1_79_0
 
      chmod +x /tmp/ngen/install_ngen.sh /tmp/t-route/install_t_route.sh /tmp/netcdf/install_netcdf_cxx.sh /tmp/extern/install_extern_libraries.sh
      chown -R root /tmp

--- a/singularity/singularity_ngen.def
+++ b/singularity/singularity_ngen.def
@@ -16,13 +16,15 @@ From: rockylinux:9.2
      dnf install tar git gcc-c++ gcc gcc-gfortran make cmake bzip2 python3 python3-devel python3-pip udunits2-devel -y
      cp -s /usr/bin/python3 /usr/bin/python
      dnf install sqlite sqlite-devel sqlite-libs libsqlite3x libsqlite3x-devel -y
-     dnf install boost boost-devel -y
+     #dnf install boost boost-devel -y
      dnf install lapack gdal-libs gdal gdal-devel -y
      pip3 install wheel 
      pip3 install deprecated dask pyarrow geopandas pyproj fiona pandas xarray netCDF4==1.6.3 joblib toolz pyyaml Cython==3.0.3 bmipy opencv-contrib-python-headless
      dnf install libstdc++ libstdc++-devel glibc glibc-devel libgfortran openmpi openmpi-devel -y
      dnf --enablerepo=devel install texinfo -y
      dnf install netcdf netcdf-devel netcdf-fortran netcdf-fortran-devel netcdf-openmpi netcdf-openmpi-devel netcdf-fortran-openmpi netcdf-fortran-openmpi-devel -y 
+     curl -L -o boost_1_79_0.tar.bz2 https://sourceforge.net/projects/boost/files/boost/1.79.0/boost_1_79_0.tar.bz2/download
+     tar -xjf boost_1_79_0.tar.bz2 /ngen/boost
 
      chmod +x /tmp/ngen/install_ngen.sh /tmp/t-route/install_t_route.sh /tmp/netcdf/install_netcdf_cxx.sh /tmp/extern/install_extern_libraries.sh
      chown -R root /tmp

--- a/singularity/templates/guide/HelloNGEN.sh
+++ b/singularity/templates/guide/HelloNGEN.sh
@@ -9,7 +9,7 @@ CYAN='\e[36m'
 RESET='\e[0m'
 
 # Increasing `ulimit` to Open files
-ulimit -n 10000
+ulimit -n 10000000
 
 # Loading Lmod
 source /etc/profile.d/modules.sh

--- a/singularity/templates/guide/HelloNGEN.sh
+++ b/singularity/templates/guide/HelloNGEN.sh
@@ -35,8 +35,8 @@ auto_select_file() {
 }
 
 # Finding files
-HYDRO_FABRIC_CATCHMENTS=$(find . -name "*catchment*.geojson")
-HYDRO_FABRIC_NEXUS=$(find . -name "*nexus*.geojson")
+HYDRO_FABRIC_CATCHMENTS=$(find . -name "*datastream*.gpkg")
+HYDRO_FABRIC_NEXUS=$(find . -name "*datastream*.gpkg")
 NGEN_REALIZATIONS=$(find . -name "*realization*.json")
 
 # Auto-selecting files if only one is found
@@ -52,12 +52,35 @@ echo -e "\n"
 echo -e "${CYAN}\e[4mFound these Realization files:${RESET}" && echo "$NGEN_REALIZATIONS" || echo -e "${RED}No Realization files found.${RESET}"
 echo -e "\n"
 
-generate_partition () {
-  # $1 catchment json file
-  # $2 nexus json file
-  # $3 number of partitions
-  /dmod/bin/partitionGenerator $1 $2 partitions_$3.json $3 '' ''
+generate_partition() {
+  /dmod/bin/partitionGenerator "$1" "$2" "partitions_$3.json" "$3" '' ''
 }
+
+if [ "$2" == "auto" ]
+  then
+    echo "AUTO MODE ENGAGED"
+    echo "Running NextGen model framework in parallel mode"
+    if [ -z "$3" ]; then
+      procs=$(($(nproc) - 2))
+    else
+      procs=$3
+    fi
+
+    partitions=$(find . -name "*partitions_$procs.json")
+    if [[ -z $partitions ]]; then
+      echo "No partitions file found, generating..."
+      generate_partition "$selected_catchment" "$selected_nexus" "$procs"
+    else
+      echo "Found paritions file! "$partitions
+    fi
+
+    mpirun -n $procs /dmod/bin/ngen-parallel $selected_catchment all $selected_nexus all $selected_realization $(pwd)/partitions_$procs.json
+    echo "Run completed successfully, exiting, have a nice day!"
+    exit 0
+  else
+    echo "Entering Interactive Mode"
+    continue
+fi
 
 echo -e "${YELLOW}Select an option (type a number): ${RESET}"
 options=("Run NextGen model framework in serial mode" "Run NextGen model framework in parallel mode" "Run Bash shell" "Exit")

--- a/singularity/templates/guide/HelloNGEN.sh
+++ b/singularity/templates/guide/HelloNGEN.sh
@@ -9,7 +9,7 @@ CYAN='\e[36m'
 RESET='\e[0m'
 
 # Increasing `ulimit` to Open files
-ulimit -n 10000000
+ulimit -n 1000000
 
 # Loading Lmod
 source /etc/profile.d/modules.sh


### PR DESCRIPTION
1. Use datastream in place of catchment and nexus
2. Update boost 1.79.0, this would be temporary fix because dnf repo does not have version 1.79.0, and once it becomes available, we will replace with dnf installation.
3. set ulimit -n 1000000, because this causes `too many open files` error when running the image.
4. Add auto mode running of the image.